### PR TITLE
Frontend/responsiveness

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -34,29 +34,20 @@ export default function HomePage() {
     <div style={{ background: "var(--color-baby-pink)", minHeight: "100vh", fontFamily: "var(--font-body)" }}>
 
       {/* ── Hero Banner ── */}
-      <section style={{
-        background: "var(--color-smooth-pink)",
-        borderBottom: "2px solid #000",
-        padding: "56px 32px",
-        textAlign: "center",
-      }}>
-        <p style={{ fontSize: "13px", letterSpacing: "3px", textTransform: "uppercase", marginBottom: "12px", opacity: 0.6 }}>
-          Homemade · Pickup Only · Oahu, Hawai'i
+      <section
+        style={{ background: "var(--color-smooth-pink)", borderBottom: "2px solid #000" }}
+        className="px-6 py-12 md:py-16 text-center"
+      >
+        <p className="text-xs md:text-sm tracking-widest uppercase mb-3 opacity-60">
+          Homemade · Pickup Only · Oahu, Hawai&apos;i
         </p>
-        <h1 style={{
-          fontSize: "clamp(32px, 6vw, 60px)",
-          fontWeight: "bold",
-          marginBottom: "20px",
-          lineHeight: 1.2,
-        }}>
+        <h1 className="font-bold mb-5 leading-tight" style={{ fontSize: "clamp(28px, 6vw, 60px)" }}>
           Seri-Seri Sweets 🍰
         </h1>
-        <p style={{
-          fontSize: "clamp(16px, 2vw, 20px)",
-          maxWidth: "560px",
-          margin: "0 auto 32px",
-          lineHeight: "1.7",
-        }}>
+        <p
+          className="mx-auto mb-8 leading-relaxed"
+          style={{ fontSize: "clamp(15px, 2vw, 20px)", maxWidth: "560px" }}
+        >
           Filipino-inspired mini cakes baked fresh with love. Order ahead for local pickup — taste a little piece of home.
         </p>
         <Link href="/menu">
@@ -79,97 +70,99 @@ export default function HomePage() {
       </section>
 
       {/* ── Featured Products (3 max) ── */}
-      <section style={{ padding: "48px 32px" }}>
-        <p style={{ fontSize: "24px", fontWeight: "bold", textAlign: "center", marginBottom: "32px" }}>
+      <section className="px-6 py-10 md:py-14">
+        <p className="text-xl md:text-2xl font-bold text-center mb-8">
           🧁 Featured Items
         </p>
 
         {loading && (
-          <p style={{ textAlign: "center", fontSize: "16px", color: "#888" }}>Loading featured items...</p>
+          <p className="text-center text-base" style={{ color: "#888" }}>Loading featured items...</p>
         )}
         {error && (
-          <p style={{ textAlign: "center", fontSize: "16px", color: "#c00" }}>{error}</p>
+          <p className="text-center text-base" style={{ color: "#c00" }}>{error}</p>
         )}
 
         {!loading && !error && (
-        <div style={{
-          display: "grid",
-          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
-          gap: "28px",
-          maxWidth: "900px",
-          margin: "0 auto",
-        }}>
-          {products.map((product) => (
-            <Card
-              key={product.id}
-              style={{
-                border: "2px solid #000",
-                borderRadius: "10px",
-                overflow: "hidden",
-                boxShadow: "3px 3px 0 #000",
-                transition: "transform 0.15s ease, box-shadow 0.15s ease",
-                background: "#fff",
-              }}
-              onMouseEnter={(e) => {
-                (e.currentTarget as HTMLElement).style.transform = "translateY(-5px)";
-                (e.currentTarget as HTMLElement).style.boxShadow = "6px 6px 0 #000";
-              }}
-              onMouseLeave={(e) => {
-                (e.currentTarget as HTMLElement).style.transform = "none";
-                (e.currentTarget as HTMLElement).style.boxShadow = "3px 3px 0 #000";
-              }}
-            >
-              <div style={{ position: "relative" }}>
-                <img
-                  src={product.picture_url}
-                  alt={product.name}
-                  style={{ width: "100%", height: "220px", objectFit: "cover", display: "block", borderBottom: "2px solid #000" }}
-                />
-                {product.badge && (
-                  <div style={{ position: "absolute", top: "10px", right: "10px" }}>
-                    <Badge style={{
-                      background: "var(--color-tender-rose)",
-                      color: "#000",
-                      border: "1px solid #000",
-                      fontFamily: "var(--font-body)",
-                      fontSize: "12px",
-                    }}>
-                      {product.badge}
-                    </Badge>
-                  </div>
-                )}
-              </div>
-
-              <CardContent style={{ padding: "16px 16px 8px" }}>
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "8px" }}>
-                  <p style={{ fontSize: "18px", fontWeight: "bold" }}>{product.name}</p>
-                  <p style={{ fontSize: "17px", fontWeight: "bold" }}>${product.price}</p>
+          <div
+            className="mx-auto"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(min(260px, 100%), 1fr))",
+              gap: "28px",
+              maxWidth: "900px",
+            }}
+          >
+            {products.map((product) => (
+              <Card
+                key={product.id}
+                style={{
+                  border: "2px solid #000",
+                  borderRadius: "10px",
+                  overflow: "hidden",
+                  boxShadow: "3px 3px 0 #000",
+                  transition: "transform 0.15s ease, box-shadow 0.15s ease",
+                  background: "#fff",
+                }}
+                onMouseEnter={(e) => {
+                  (e.currentTarget as HTMLElement).style.transform = "translateY(-5px)";
+                  (e.currentTarget as HTMLElement).style.boxShadow = "6px 6px 0 #000";
+                }}
+                onMouseLeave={(e) => {
+                  (e.currentTarget as HTMLElement).style.transform = "none";
+                  (e.currentTarget as HTMLElement).style.boxShadow = "3px 3px 0 #000";
+                }}
+              >
+                <div style={{ position: "relative" }}>
+                  <img
+                    src={product.picture_url}
+                    alt={product.name}
+                    style={{ width: "100%", height: "220px", objectFit: "cover", display: "block", borderBottom: "2px solid #000" }}
+                  />
+                  {product.badge && (
+                    <div style={{ position: "absolute", top: "10px", right: "10px" }}>
+                      <Badge style={{
+                        background: "var(--color-tender-rose)",
+                        color: "#000",
+                        border: "1px solid #000",
+                        fontFamily: "var(--font-body)",
+                        fontSize: "12px",
+                      }}>
+                        {product.badge}
+                      </Badge>
+                    </div>
+                  )}
                 </div>
-                <p style={{ fontSize: "14px", color: "#555", lineHeight: "1.5" }}>{product.description}</p>
-              </CardContent>
 
-              <CardFooter style={{ padding: "8px 16px 16px" }}>
-                <Link href="/menu" style={{ width: "100%" }}>
-                  <Button style={{
-                    width: "100%",
-                    background: "var(--color-papaya)",
-                    border: "1.5px solid #000",
-                    color: "#000",
-                    fontFamily: "var(--font-body)",
-                    fontWeight: "bold",
-                    height: "auto",
-                    padding: "8px",
-                  }}>
-                    Order This
-                  </Button>
-                </Link>
-              </CardFooter>
-            </Card>
-          ))}
-        </div>
+                <CardContent style={{ padding: "16px 16px 8px" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "8px" }}>
+                    <p style={{ fontSize: "18px", fontWeight: "bold" }}>{product.name}</p>
+                    <p style={{ fontSize: "17px", fontWeight: "bold" }}>${product.price}</p>
+                  </div>
+                  <p style={{ fontSize: "14px", color: "#555", lineHeight: "1.5" }}>{product.description}</p>
+                </CardContent>
+
+                <CardFooter style={{ padding: "8px 16px 16px" }}>
+                  <Link href="/menu" style={{ width: "100%" }}>
+                    <Button style={{
+                      width: "100%",
+                      background: "var(--color-papaya)",
+                      border: "1.5px solid #000",
+                      color: "#000",
+                      fontFamily: "var(--font-body)",
+                      fontWeight: "bold",
+                      height: "auto",
+                      padding: "8px",
+                    }}>
+                      Order This
+                    </Button>
+                  </Link>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
         )}
 
-        <div style={{ textAlign: "center", marginTop: "32px" }}>
+        <div className="text-center mt-8">
           <Link href="/menu">
             <Button style={{
               background: "var(--color-smooth-pink)",
@@ -186,21 +179,14 @@ export default function HomePage() {
         </div>
       </section>
 
-      <hr style={{ borderColor: "#000", margin: "0 32px" }} />
-
       {/* ── About Section ── */}
-      <section style={{
-        background: "var(--color-tender-rose)",
-        borderTop: "2px solid #000",
-        borderBottom: "2px solid #000",
-        padding: "48px 32px",
-        textAlign: "center",
-      }}>
-        <p style={{ fontSize: "24px", fontWeight: "bold", marginBottom: "16px" }}>
-          About Seri-Seri Sweets
-        </p>
-        <p style={{ fontSize: "18px", maxWidth: "560px", margin: "0 auto 28px", lineHeight: "1.7" }}>
-          A Filipino family bakery bringing the warmth of home to Oahu, Hawai'i — one mini cake at a time. 🌺
+      <section
+        style={{ background: "var(--color-tender-rose)", borderTop: "2px solid #000", borderBottom: "2px solid #000" }}
+        className="px-6 py-10 md:py-14 text-center"
+      >
+        <p className="text-xl md:text-2xl font-bold mb-4">About Seri-Seri Sweets</p>
+        <p className="text-base md:text-lg mx-auto mb-7 leading-relaxed" style={{ maxWidth: "560px" }}>
+          A Filipino family bakery bringing the warmth of home to Oahu, Hawai&apos;i — one mini cake at a time. 🌺
         </p>
         <Link href="/about">
           <Button style={{
@@ -219,20 +205,18 @@ export default function HomePage() {
       </section>
 
       {/* ── Contact Section ── */}
-      <section style={{
-        background: "var(--color-smooth-pink)",
-        borderBottom: "2px solid #000",
-        padding: "48px 32px",
-        textAlign: "center",
-      }}>
-        <p style={{ fontSize: "24px", fontWeight: "bold", marginBottom: "20px" }}>Contact & Pickup</p>
-        <p style={{ fontSize: "18px", lineHeight: "2.4" }}>
-          📧 seriseri.sweets@gmail.com<br />
-          📞 (619) 679-6669<br />
-          📍 Pearl City, Hawai'i<br />
-          🕐 <em style={{ color: "#888" }}>(pickup hours coming soon)</em><br />
-          <strong>Pickup Only</strong> · Orders confirmed by owner
-        </p>
+      <section
+        style={{ background: "var(--color-smooth-pink)", borderBottom: "2px solid #000" }}
+        className="px-6 py-10 md:py-14 text-center"
+      >
+        <p className="text-xl md:text-2xl font-bold mb-6">Contact &amp; Pickup</p>
+        <div className="flex flex-col items-center gap-3 text-base md:text-lg">
+          <p>📧 seriseri.sweets@gmail.com</p>
+          <p>📞 (619) 679-6669</p>
+          <p>📍 Pearl City, Hawai&apos;i</p>
+          <p><em style={{ color: "#888" }}>🕐 (pickup hours coming soon)</em></p>
+          <p><strong>Pickup Only</strong> · Orders confirmed by owner</p>
+        </div>
       </section>
 
     </div>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -227,9 +227,9 @@ export default function HomePage() {
       }}>
         <p style={{ fontSize: "24px", fontWeight: "bold", marginBottom: "20px" }}>Contact & Pickup</p>
         <p style={{ fontSize: "18px", lineHeight: "2.4" }}>
-          📧 <em style={{ color: "#888" }}>(business email coming soon)</em><br />
-          📞 <em style={{ color: "#888" }}>(phone number coming soon)</em><br />
-          📍 <em style={{ color: "#888" }}>(address coming soon)</em> — Oahu, Hawai'i<br />
+          📧 seriseri.sweets@gmail.com<br />
+          📞 (619) 679-6669<br />
+          📍 Pearl City, Hawai'i<br />
           🕐 <em style={{ color: "#888" }}>(pickup hours coming soon)</em><br />
           <strong>Pickup Only</strong> · Orders confirmed by owner
         </p>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,39 +1,35 @@
 // frontend/app/page.tsx
 "use client";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Product } from "@/types/product";
-
-const products: Product[] = [ 
-  {
-    id: 1,
-    name: "Chocolate Mini Cake",
-    price: "$6.00",
-    description: "Rich chocolate cupcake topped with fluffy chocolate buttercream.",
-    img: "https://placehold.co/400x300/c8a882/5a3e2b?text=Chocolate+Mini+Cake",
-    badge: null,
-  },
-  {
-    id: 2,
-    name: "Ube Mini Cake",
-    price: "$10.00",
-    description: "Soft ube cupcake with creamy ube buttercream and sweet nutty flavor.",
-    img: "https://placehold.co/400x300/c9a8e0/5b2d8e?text=Ube+Mini+Cake",
-    badge: "Popular",
-  },
-  {
-    id: 3,
-    name: "Sampler Box",
-    price: "$30.00",
-    description: "One of each flavor — Chocolate, Vanilla, Turon, and Ube — perfect for trying them all!",
-    img: "https://placehold.co/400x300/e8d5b7/7a5c3a?text=Sampler+Box",
-    badge: "Best Value",
-  },
-];
+import { getMenu } from "@/data/menu";
 
 export default function HomePage() {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadFeatured() {
+      try {
+        setLoading(true);
+        setError(null);
+        const data = await getMenu();
+        setProducts(data.slice(0, 3));
+      } catch (err) {
+        console.error(err);
+        setError("Could not load featured items.");
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadFeatured();
+  }, []);
+
   return (
     <div style={{ background: "var(--color-baby-pink)", minHeight: "100vh", fontFamily: "var(--font-body)" }}>
 
@@ -88,6 +84,14 @@ export default function HomePage() {
           🧁 Featured Items
         </p>
 
+        {loading && (
+          <p style={{ textAlign: "center", fontSize: "16px", color: "#888" }}>Loading featured items...</p>
+        )}
+        {error && (
+          <p style={{ textAlign: "center", fontSize: "16px", color: "#c00" }}>{error}</p>
+        )}
+
+        {!loading && !error && (
         <div style={{
           display: "grid",
           gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
@@ -117,7 +121,7 @@ export default function HomePage() {
             >
               <div style={{ position: "relative" }}>
                 <img
-                  src={product.img}
+                  src={product.picture_url}
                   alt={product.name}
                   style={{ width: "100%", height: "220px", objectFit: "cover", display: "block", borderBottom: "2px solid #000" }}
                 />
@@ -139,7 +143,7 @@ export default function HomePage() {
               <CardContent style={{ padding: "16px 16px 8px" }}>
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", marginBottom: "8px" }}>
                   <p style={{ fontSize: "18px", fontWeight: "bold" }}>{product.name}</p>
-                  <p style={{ fontSize: "17px", fontWeight: "bold" }}>{product.price}</p>
+                  <p style={{ fontSize: "17px", fontWeight: "bold" }}>${product.price}</p>
                 </div>
                 <p style={{ fontSize: "14px", color: "#555", lineHeight: "1.5" }}>{product.description}</p>
               </CardContent>
@@ -163,6 +167,7 @@ export default function HomePage() {
             </Card>
           ))}
         </div>
+        )}
 
         <div style={{ textAlign: "center", marginTop: "32px" }}>
           <Link href="/menu">

--- a/frontend/components/navbar.tsx
+++ b/frontend/components/navbar.tsx
@@ -1,48 +1,130 @@
-
+"use client";
 import Link from "next/link";
+import { useState } from "react";
+import { useCart } from "@/context/CartContext";
+
+const navLinks = [
+  { label: "Home",  href: "/" },
+  { label: "Menu",  href: "/menu" },
+  { label: "About", href: "/about" },
+];
 
 export default function Navbar() {
-  return (
-    <nav style={{ background: "var(--color-papaya)", borderBottom: "1px solid var(--color-smooth-pink)" }}
-      className="flex items-center justify-between px-6 h-16">
+  const { items } = useCart();
+  const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
+  const [menuOpen, setMenuOpen] = useState(false);
 
-      {/* Store name + links centered together */}
-      <div className="flex items-center gap-4 mx-auto">
-        <Link href="/"
+  return (
+    <nav
+      style={{ background: "var(--color-papaya)", borderBottom: "1px solid var(--color-smooth-pink)" }}
+      className="relative px-6"
+    >
+      {/* ── Main row ── */}
+      <div className="flex items-center justify-between h-16 md:h-20">
+
+        {/* Store name */}
+        <Link
+          href="/"
           style={{ color: "var(--color-foreground)", fontFamily: "var(--font-display)" }}
-          className="text-3xl font-bold hover:opacity-80">
+          className="text-2xl md:text-4xl font-bold hover:opacity-80 shrink-0"
+        >
           Seri Seri Sweets
         </Link>
 
-        <span style={{ color: "var(--color-foreground)" }}>|</span>
+        {/* Desktop nav links */}
+        <div className="hidden md:flex items-center gap-4">
+          <span style={{ color: "var(--color-foreground)" }}>|</span>
+          {navLinks.map(({ label, href }, i, arr) => (
+            <span key={label} className="flex items-center gap-4">
+              <Link
+                href={href}
+                style={{ color: "var(--color-foreground)", fontFamily: "var(--font-body)" }}
+                className="text-xl hover:opacity-60"
+              >
+                {label}
+              </Link>
+              {i < arr.length - 1 && (
+                <span style={{ color: "var(--color-foreground)" }}>|</span>
+              )}
+            </span>
+          ))}
+        </div>
 
-        {[
-          { label: "Home",    href: "/" },
-          { label: "Menu",    href: "/menu" },
-          { label: "About",   href: "/about" },
-        ].map(({ label, href }, i, arr) => (
-          <span key={label} className="flex items-center gap-4">
-            <Link href={href}
-              style={{ color: "var(--color-foreground)", fontFamily: "var(--font-body)" }}
-              className="text-xl hover:opacity-60">
-              {label}
-            </Link>
-            {i < arr.length - 1 && (
-              <span style={{ color: "var(--color-foreground)" }}>|</span>
+        {/* Right side: cart + hamburger */}
+        <div className="flex items-center gap-4">
+          <Link
+            href="/checkout"
+            style={{ color: "var(--color-foreground)" }}
+            className="relative hover:opacity-60"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28"
+              fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+              <path strokeLinecap="round" strokeLinejoin="round"
+                d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13l-1.5 6h13M7 13L5.4 5M10 21a1 1 0 100-2 1 1 0 000 2zm8 0a1 1 0 100-2 1 1 0 000 2z" />
+            </svg>
+            {itemCount > 0 && (
+              <span style={{
+                position: "absolute", top: "-8px", right: "-8px",
+                background: "var(--color-tender-rose)",
+                border: "1.5px solid #000",
+                borderRadius: "9999px",
+                fontSize: "11px",
+                fontWeight: "bold",
+                fontFamily: "var(--font-body)",
+                minWidth: "18px",
+                height: "18px",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: "0 4px",
+                color: "#000",
+              }}>
+                {itemCount}
+              </span>
             )}
-          </span>
-        ))}
+          </Link>
+
+          {/* Hamburger (mobile only) */}
+          <button
+            className="md:hidden flex flex-col justify-center gap-1.5 w-8 h-8 shrink-0"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label="Toggle menu"
+          >
+            <span
+              style={{ background: "var(--color-foreground)" }}
+              className={`block h-0.5 w-full rounded transition-transform duration-200 ${menuOpen ? "rotate-45 translate-y-2" : ""}`}
+            />
+            <span
+              style={{ background: "var(--color-foreground)" }}
+              className={`block h-0.5 w-full rounded transition-opacity duration-200 ${menuOpen ? "opacity-0" : ""}`}
+            />
+            <span
+              style={{ background: "var(--color-foreground)" }}
+              className={`block h-0.5 w-full rounded transition-transform duration-200 ${menuOpen ? "-rotate-45 -translate-y-2" : ""}`}
+            />
+          </button>
+        </div>
       </div>
 
-      {/* Cart icon — right side */}
-      <Link href="/checkout" style={{ color: "var(--color-foreground)" }} className="hover:opacity-60">
-        <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22"
-          fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
-          <path strokeLinecap="round" strokeLinejoin="round"
-            d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13l-1.5 6h13M7 13L5.4 5M10 21a1 1 0 100-2 1 1 0 000 2zm8 0a1 1 0 100-2 1 1 0 000 2z" />
-        </svg>
-      </Link>
-
+      {/* ── Mobile dropdown ── */}
+      {menuOpen && (
+        <div
+          style={{ borderTop: "1px solid #000", background: "var(--color-papaya)" }}
+          className="md:hidden flex flex-col gap-1 pb-4 pt-3"
+        >
+          {navLinks.map(({ label, href }) => (
+            <Link
+              key={label}
+              href={href}
+              style={{ color: "var(--color-foreground)", fontFamily: "var(--font-body)" }}
+              className="text-lg px-2 py-2 hover:opacity-60"
+              onClick={() => setMenuOpen(false)}
+            >
+              {label}
+            </Link>
+          ))}
+        </div>
+      )}
     </nav>
   );
 }


### PR DESCRIPTION
- Added hamburger menu to navbar for mobile — collapses nav links into a dropdown, closes on link tap
- Store name scales down on mobile (text-2xl → text-4xl at md breakpoint)
- Replaced fixed inline padding on homepage sections with responsive Tailwind classes
- Fixed product grid minmax(260px) overflow on narrow phone

To test, Resize browser below 768px — hamburger appears, desktop links hide, Verify product cards don't overflow on a 375px screen